### PR TITLE
fix broken animation due to never setting fromValue

### DIFF
--- a/Hamburger Button/HamburgerButton.swift
+++ b/Hamburger Button/HamburgerButton.swift
@@ -147,7 +147,7 @@ extension CALayer {
     func ocb_applyAnimation(animation: CABasicAnimation) {
         let copy = animation.copy() as CABasicAnimation
 
-        if copy.fromValue != nil {
+        if copy.fromValue == nil {
             copy.fromValue = self.presentationLayer().valueForKeyPath(copy.keyPath)
         }
 


### PR DESCRIPTION
Without the change, the button would switch state immediately without animation.
