### PR TITLE
Swift 2.0 enum usage for kCGLineCapRound & kCGJoinMilter

### DIFF
--- a/Hamburger Button/HamburgerButton.swift
+++ b/Hamburger Button/HamburgerButton.swift
@@ -58,7 +58,7 @@ class HamburgerButton : UIButton {
             layer.lineCap = kCALineCapRound
             layer.masksToBounds = true
 
-            let strokingPath = CGPathCreateCopyByStrokingPath(layer.path, nil, 4, kCGLineCapRound, kCGLineJoinMiter, 4)
+            let strokingPath = CGPathCreateCopyByStrokingPath(layer.path, nil, 4, .Round, .Milter, 4)
 
             layer.bounds = CGPathGetPathBoundingBox(strokingPath)
 


### PR DESCRIPTION
kCGLineCapRound -> .Round
kCGLineJoinMiter -> .Milter